### PR TITLE
Add link for Adobe careers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## Hiring
 
-- [Adobe](https://www.adobe.com/careers.html)
+- [Adobe](https://www.adobe.com/careers.html), ([direct search for the Edinburgh Office](https://adobe.wd5.myworkdayjobs.com/external_experienced?locations=3ba4ecdf4893100bc84ae0da81726bfc))
 
 
 ## Nearby


### PR DESCRIPTION
Adobe has an engineering office in Edinburgh (near Hermiston Gait in Sighthill), so adding a link to our careers page - we're hiring now!